### PR TITLE
fix(minify): add space between 'return' and numeric tokens

### DIFF
--- a/src/minify.ts
+++ b/src/minify.ts
@@ -585,6 +585,10 @@ export class GlslMinify {
             if (token === '0' && prevType === TokenType.ttDot) {
               break;
             }
+            // Special case if the numeric token follows a "return" token and it needs a space between (e.g "return 1")
+            if(prevToken === 'return'){
+              output += ' ';
+            }
           }
           // eslint-disable-next-line no-fallthrough
 


### PR DESCRIPTION
Bug fix: 
**scenario:**
minify statements similar to this:
float test(float m){
  return 1 / m ;
}

**Expected result:**
float test(float m){return 1/m ;}

**Actual result:**
float test(float m){return1/m ;} // This does not compile