### PR TITLE
Fixing bug when using comma-separated uniform declarations

### DIFF
--- a/src/__tests__/minify.test.ts
+++ b/src/__tests__/minify.test.ts
@@ -182,4 +182,49 @@ describe('GlslMinify', () => {
     const expected = '{prop1:"hello",prop2:{vals:[0,1,2],num:1.23}}';
     expect(str).toEqual(expected);
   });
+
+  it('Supports multiple uniforms on a single line, comma-separated', async (done) => {
+    const glsl = new GlslMinifyInternal({}, nodeReadFile, nodeDirname);
+    const file = await glsl.readFile('tests/glsl/commas-uniforms.glsl');
+    const output = await glsl.executeFile(file);
+
+    // Uniforms are detected and minified
+    expect(output.uniforms.uRed.variableName).toEqual('A');
+    expect(output.uniforms.uRed.variableType).toEqual('float');
+    expect(output.uniforms.uGreen.variableName).toEqual('B');
+    expect(output.uniforms.uGreen.variableType).toEqual('float');
+    expect(output.uniforms.uBlue.variableName).toEqual('C');
+    expect(output.uniforms.uBlue.variableType).toEqual('float');
+
+    // Compare against the expected output
+    const expected = await glsl.readFile('tests/glsl/commas-uniforms.min.glsl');
+    expect(output.sourceCode).toEqual(trim(expected.contents));
+    done();
+  });
+
+  it('Supports multiple uniforms on a single line, comma-separated, with preserveUniforms', async (done) => {
+    const glsl = new GlslMinifyInternal({ preserveUniforms: true }, nodeReadFile, nodeDirname);
+    const file = await glsl.readFile('tests/glsl/commas-uniforms.glsl');
+    const output = await glsl.executeFile(file);
+
+    // Uniforms are not minified
+    expect(output.uniforms.uRed.variableName).toEqual('uRed');
+    expect(output.uniforms.uRed.variableType).toEqual('float');
+    expect(output.uniforms.uGreen.variableName).toEqual('uGreen');
+    expect(output.uniforms.uGreen.variableType).toEqual('float');
+    expect(output.uniforms.uBlue.variableName).toEqual('uBlue');
+    expect(output.uniforms.uBlue.variableType).toEqual('float');
+    done();
+  });
+
+  it('Supports multiple variables declared and initialized on a single line, comma-separated', async (done) => {
+    const glsl = new GlslMinifyInternal({}, nodeReadFile, nodeDirname);
+    const file = await glsl.readFile('tests/glsl/commas-variables.glsl');
+    const output = await glsl.executeFile(file);
+
+    // Compare against the expected output
+    const expected = await glsl.readFile('tests/glsl/commas-variables.min.glsl');
+    expect(output.sourceCode).toEqual(trim(expected.contents));
+    done();
+  });
 });

--- a/tests/glsl/commas-uniforms.glsl
+++ b/tests/glsl/commas-uniforms.glsl
@@ -1,0 +1,7 @@
+// Instantiate multiple uniforms on a single line, comma-separated
+uniform float uRed, uGreen, uBlue;
+
+void main()
+{
+  gl_FragColor = vec4(uRed, uGreen, uBlue, 1.0);
+}

--- a/tests/glsl/commas-uniforms.min.glsl
+++ b/tests/glsl/commas-uniforms.min.glsl
@@ -1,0 +1,1 @@
+uniform float A,B,C;void main(){gl_FragColor=vec4(A,B,C,1.);}

--- a/tests/glsl/commas-variables.glsl
+++ b/tests/glsl/commas-variables.glsl
@@ -1,0 +1,10 @@
+void main()
+{
+  // Multiple variables can be defined on a single line, separated by commas
+  float red, green, blue = 0.5, alpha = 1.0;
+
+  // Multiple variables can be initialized on a single line, separated by commas
+  red = 0.5, blue = 0.5;
+
+  gl_FragColor = vec4(red, green, blue, alpha);
+}

--- a/tests/glsl/commas-variables.min.glsl
+++ b/tests/glsl/commas-variables.min.glsl
@@ -1,0 +1,1 @@
+void main(){float A,B,C=0.5,D=1.;A=0.5,C=0.5;gl_FragColor=vec4(A,B,C,D);}


### PR DESCRIPTION
We now handle `uniform a, b, c;` correctly.