### PR TITLE
Fixing one more variation of issue #23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-glsl-minify",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-glsl-minify",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "author": "Leo C. Singleton IV <leo@leosingleton.com>",
   "description": "GLSL Loader, Preprocessor, and Minifier for Webpack",
   "homepage": "https://github.com/leosingleton/webpack-glsl-minify",

--- a/src/minify.ts
+++ b/src/minify.ts
@@ -586,10 +586,10 @@ export class GlslMinify {
 
     // The token regex looks for any of four items:
     //  1) An alphanumeric token (\w+), which may include underscores (or $ for substitution values)
-    //  2) One or more operators (non-alphanumeric, non-dot)
+    //  2) An operators (non-alphanumeric, non-dot). May consist of 2 characters if it ends in an =, e.g. <=, +=, or ==.
     //  3) A dot operator
     //  4) GLSL preprocessor directive beginning with #
-    const tokenRegex = /[\w$]+|[^\s\w#.]+|\.|#.*/g;
+    const tokenRegex = /[\w$]+|[^\s\w#.]=?|\.|#.*/g;
 
     //
     // Minifying uses a simple state machine which tracks the following four state variables:

--- a/tests/cases/uniform-array-of-const-2.glsl
+++ b/tests/cases/uniform-array-of-const-2.glsl
@@ -1,0 +1,22 @@
+precision mediump float;
+varying vec2 vCoord;
+
+/** Input image */
+uniform sampler2D uInput;
+
+/** Number of pixels to sample */
+@const int PIXELS
+
+/** Pixels to sample. The X and Y in the vector are the offset. The Z is the weight. */
+uniform vec3 uPixels[PIXELS];
+
+void main()
+{
+  vec4 sum = vec4(0.0);
+  for (int n = 0; n < PIXELS; n++) {
+    vec3 pixel = uPixels[n];
+    sum += texture2D(uInput, vCoord + pixel.xy) * pixel.z;
+  }
+
+  gl_FragColor = sum;
+}

--- a/tests/cases/uniform-array-of-const-2.json
+++ b/tests/cases/uniform-array-of-const-2.json
@@ -1,0 +1,19 @@
+{
+  "sourceCode": "precision mediump float;varying vec2 vCoord;uniform sampler2D A;const int B=$0$;uniform vec3 C[B];void main(){vec4 D=vec4(0.);for(int E=0;E<B;E++){vec3 F=C[E];D+=texture2D(A,vCoord+F.xy)*F.z;}gl_FragColor=D;}",
+  "consts": {
+    "PIXELS": {
+      "variableName": "$0$",
+      "variableType": "int"
+    }
+  },
+  "uniforms": {
+    "uInput": {
+      "variableName": "A",
+      "variableType": "sampler2D"
+    },
+    "uPixels": {
+      "variableName": "C",
+      "variableType": "vec3"
+    }
+  }
+}


### PR DESCRIPTION
Regular variables were getting reported as uniforms because of the
way operators were parsed. A bug in the tokenizing regex caused
"];" to be treated as a single, non-semicolon, operator.