### PR TITLE
Adding support for ES modules output

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ This loader also supports the following loader-specific options:
 * `output`: Default `'object'`, which outputs JavaScript code which exports an object described in the section above.
     Alternatively, `'source'` may be specified which exports only a string containing the source code instead.
     Selecting `'source'` automatically disables mangling of uniforms as there is no output map of the mangled names.
+* `esModule`: Default `false`. Uses ES modules syntax instead of CommonJS. Applies to the "object" and "source"
+    output formats.
 * `stripVersion`: Default `false`. Strips any `#version` directives.
 * `preserveDefines`: Default `false`. Disables name mangling of `#define`s.
 * `preserveUniforms`: Default `false`. Disables name mangling of uniforms.
@@ -174,6 +176,8 @@ Options:
                        the same directory as the input .glsl file.      [string]
   --output             Output format
                  [choices: "object", "source", "sourceOnly"] [default: "object"]
+  --esModule           Uses ES modules syntax. Applies to the "object" and
+                       "source" output formats.                        [boolean]
   --stripVersion       Strips any #version directives                  [boolean]
   --preserveDefines    Disables name mangling of #defines              [boolean]
   --preserveUniforms   Disables name mangling of uniforms              [boolean]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-glsl-minify",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -247,18 +247,18 @@
       "dev": true
     },
     "@types/uglify-js": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.5.tgz",
-      "integrity": "sha512-L7EbSkhSaWBpkl+PZAEAqZTqtTeIsq7s/oX/q0LNnxxJoRVKQE0T81XDVyaxjiiKQwiV2vhVeYRqxdRNqGOGJw==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.0.tgz",
+      "integrity": "sha512-3ZcoyPYHVOCcLpnfZwD47KFLr8W/mpUcgjpf1M4Q78TMJIw7KMAHSjiCLJp1z3ZrBR9pTLbe191O0TldFK5zcw==",
       "dev": true,
       "requires": {
         "source-map": "^0.6.1"
       }
     },
     "@types/webpack": {
-      "version": "4.41.10",
-      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.10.tgz",
-      "integrity": "sha512-vIy0qaq8AjOjZLuFPqpo7nAJzcoVXMdw3mvpNN07Uvdy0p1IpJeLNBe3obdRP7FX2jIusDE7z1pZa0A6qYUgnA==",
+      "version": "4.41.11",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.11.tgz",
+      "integrity": "sha512-PtEZISfBMWL05qOpZN19hztZPt0rPuGQh5sbBP3bB4RrJgzdb0SScn47hdcMaoN1IgaU7NZWeDO6reFcKTK2iQ==",
       "dev": true,
       "requires": {
         "@types/anymatch": "*",
@@ -296,45 +296,45 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.27.0.tgz",
-      "integrity": "sha512-/my+vVHRN7zYgcp0n4z5A6HAK7bvKGBiswaM5zIlOQczsxj/aiD7RcgD+dvVFuwFaGh5+kM7XA6Q6PN0bvb1tw==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.28.0.tgz",
+      "integrity": "sha512-w0Ugcq2iatloEabQP56BRWJowliXUP5Wv6f9fKzjJmDW81hOTBxRoJ4LoEOxRpz9gcY51Libytd2ba3yLmSOfg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.27.0",
+        "@typescript-eslint/experimental-utils": "2.28.0",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
         "tsutils": "^3.17.1"
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.27.0.tgz",
-      "integrity": "sha512-vOsYzjwJlY6E0NJRXPTeCGqjv5OHgRU1kzxHKWJVPjDYGbPgLudBXjIlc+OD1hDBZ4l1DLbOc5VjofKahsu9Jw==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.28.0.tgz",
+      "integrity": "sha512-4SL9OWjvFbHumM/Zh/ZeEjUFxrYKtdCi7At4GyKTbQlrj1HcphIDXlje4Uu4cY+qzszR5NdVin4CCm6AXCjd6w==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.27.0",
+        "@typescript-eslint/typescript-estree": "2.28.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.27.0.tgz",
-      "integrity": "sha512-HFUXZY+EdwrJXZo31DW4IS1ujQW3krzlRjBrFRrJcMDh0zCu107/nRfhk/uBasO8m0NVDbBF5WZKcIUMRO7vPg==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.28.0.tgz",
+      "integrity": "sha512-RqPybRDquui9d+K86lL7iPqH6Dfp9461oyqvlXMNtap+PyqYbkY5dB7LawQjDzot99fqzvS0ZLZdfe+1Bt3Jgw==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.27.0",
-        "@typescript-eslint/typescript-estree": "2.27.0",
+        "@typescript-eslint/experimental-utils": "2.28.0",
+        "@typescript-eslint/typescript-estree": "2.28.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.27.0.tgz",
-      "integrity": "sha512-t2miCCJIb/FU8yArjAvxllxbTiyNqaXJag7UOpB5DVoM3+xnjeOngtqlJkLRnMtzaRcJhe3CIR9RmL40omubhg==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.28.0.tgz",
+      "integrity": "sha512-HDr8MP9wfwkiuqzRVkuM3BeDrOC4cKbO5a6BymZBHUt5y/2pL0BXD6I/C/ceq2IZoHWhcASk+5/zo+dwgu9V8Q==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -1787,54 +1787,18 @@
       "from": "github:leosingleton/eslint-config-leosingleton",
       "dev": true,
       "requires": {
-        "@typescript-eslint/parser": "^2.26.0"
+        "@typescript-eslint/parser": "^2.28.0"
       },
       "dependencies": {
-        "@typescript-eslint/experimental-utils": {
-          "version": "2.26.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.26.0.tgz",
-          "integrity": "sha512-RELVoH5EYd+JlGprEyojUv9HeKcZqF7nZUGSblyAw1FwOGNnmQIU8kxJ69fttQvEwCsX5D6ECJT8GTozxrDKVQ==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.3",
-            "@typescript-eslint/typescript-estree": "2.26.0",
-            "eslint-scope": "^5.0.0",
-            "eslint-utils": "^2.0.0"
-          }
-        },
         "@typescript-eslint/parser": {
-          "version": "2.26.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.26.0.tgz",
-          "integrity": "sha512-+Xj5fucDtdKEVGSh9353wcnseMRkPpEAOY96EEenN7kJVrLqy/EVwtIh3mxcUz8lsFXW1mT5nN5vvEam/a5HiQ==",
+          "version": "2.28.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.28.0.tgz",
+          "integrity": "sha512-RqPybRDquui9d+K86lL7iPqH6Dfp9461oyqvlXMNtap+PyqYbkY5dB7LawQjDzot99fqzvS0ZLZdfe+1Bt3Jgw==",
           "dev": true,
           "requires": {
             "@types/eslint-visitor-keys": "^1.0.0",
-            "@typescript-eslint/experimental-utils": "2.26.0",
-            "@typescript-eslint/typescript-estree": "2.26.0",
-            "eslint-visitor-keys": "^1.1.0"
-          }
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "2.26.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.26.0.tgz",
-          "integrity": "sha512-3x4SyZCLB4zsKsjuhxDLeVJN6W29VwBnYpCsZ7vIdPel9ZqLfIZJgJXO47MNUkurGpQuIBALdPQKtsSnWpE1Yg==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "eslint-visitor-keys": "^1.1.0",
-            "glob": "^7.1.6",
-            "is-glob": "^4.0.1",
-            "lodash": "^4.17.15",
-            "semver": "^6.3.0",
-            "tsutils": "^3.17.1"
-          }
-        },
-        "eslint-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
-          "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
-          "dev": true,
-          "requires": {
+            "@typescript-eslint/experimental-utils": "2.28.0",
+            "@typescript-eslint/typescript-estree": "2.28.0",
             "eslint-visitor-keys": "^1.1.0"
           }
         }
@@ -2091,9 +2055,9 @@
       }
     },
     "eslint-plugin-jsdoc": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-22.1.0.tgz",
-      "integrity": "sha512-54NdbICM7KrxsGUqQsev9aIMqPXyvyBx2218Qcm0TQ16P9CtBI+YY4hayJR6adrxlq4Ej0JLpgfUXWaQVFqmQg==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-23.0.0.tgz",
+      "integrity": "sha512-zj5ZephjKkFU/J9hEw3RcjwpuywChvwNMgHs2DTgOuKarpJ65SJU3JGgx/K4y9l8iFw0ysrk6NlAKDX88ZwZdw==",
       "dev": true,
       "requires": {
         "comment-parser": "^0.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-glsl-minify",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "author": "Leo C. Singleton IV <leo@leosingleton.com>",
   "description": "GLSL Loader, Preprocessor, and Minifier for Webpack",
   "homepage": "https://github.com/leosingleton/webpack-glsl-minify",

--- a/src/__tests__/webpack.test.ts
+++ b/src/__tests__/webpack.test.ts
@@ -72,4 +72,12 @@ describe('Webpack Loader', () => {
     expect(output).toContain('mat3 transform');
     expect(output).toContain('YCbCr2RGB(');                 // Function names are not mangled with preserveAll
   });
+
+  it('Outputs an ES module', async () => {
+    const output = await runWebpack('webpack.test7.js');
+    expect(output).toContain('gl_FragColor=vec4');
+    expect(output.indexOf('u_cb;')).toEqual(-1);            // Uniforms are minified by default
+    expect(output.indexOf('mat3 transform')).toEqual(-1);   // Variables are minified by default
+    expect(output).toContain('#version');                   // #version directives are preserved by default
+  });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ interface Arguments {
   ext: string;
   outDir?: string;
   output?: GlslOutputFormat;
+  esModule?: boolean;
   stripVersion?: boolean;
   preserveDefines?: boolean;
   preserveUniforms?: boolean;
@@ -44,6 +45,10 @@ const argv = yargs
       choices: outputFormats,
       describe: 'Output format',
       default: 'object'
+    },
+    esModule: {
+      describe: 'Uses ES modules syntax. Applies to the "object" and "source" output formats.',
+      type: 'boolean'
     },
     stripVersion: {
       describe: 'Strips any #version directives',
@@ -76,6 +81,7 @@ const argv = yargs
 // Create minifier
 const glsl = new GlslMinify({
   output: argv.output,
+  esModule: argv.esModule,
   stripVersion: argv.stripVersion,
   preserveDefines: argv.preserveDefines,
   preserveUniforms: argv.preserveUniforms,

--- a/src/minify.ts
+++ b/src/minify.ts
@@ -304,6 +304,9 @@ export interface GlslMinifyOptions {
   /** Output format. Default = 'object'. */
   output?: GlslOutputFormat;
 
+  /** Uses ES modules syntax. Applies to the "object" and "source" output formats. Default = false. */
+  esModule?: boolean;
+
   /** Strips any #version directives. Default = false. */
   stripVersion?: boolean;
 
@@ -762,17 +765,18 @@ export class GlslMinify {
 
   public async executeFileAndStringify(input: GlslFile): Promise<string> {
     const program = await this.executeFile(input);
+    const esModule = this.options.esModule;
 
     switch (this.options.output) {
       case 'sourceOnly':
         return program.sourceCode;
 
       case 'source':
-        return 'module.exports = ' + GlslMinify.stringify(program.sourceCode);
+        return `${esModule ? 'export default' : 'module.exports ='} ${GlslMinify.stringify(program.sourceCode)}`;
 
       case 'object':
       default:
-        return 'module.exports = ' + GlslMinify.stringify(program);
+        return `${esModule ? 'export default' : 'module.exports ='} ${GlslMinify.stringify(program)}`;
     }
   }
 

--- a/tests/webpack/index-es.js
+++ b/tests/webpack/index-es.js
@@ -1,0 +1,7 @@
+'use strict';
+
+// Embed a GLSL file
+import glsl from './glsl/test.glsl';
+
+// We must do something with the GlslShader object to avoid it getting optimized away
+console.log(JSON.stringify(glsl));

--- a/tests/webpack/webpack.test7.js
+++ b/tests/webpack/webpack.test7.js
@@ -1,0 +1,25 @@
+const path = require('path');
+
+module.exports = {
+  entry: './index-es.js',
+  module: {
+    rules: [
+      {
+        test: /\.glsl$/,
+        use: {
+          loader: '../../',
+          options: {
+            esModule: true
+          }
+        }
+      }
+    ]
+  },
+  resolve: {
+    extensions: [ '.glsl' ]
+  },
+  output: {
+    path: path.resolve(__dirname, '../../build/__tests__/webpack'),
+    filename: 'index.js'
+  }
+};


### PR DESCRIPTION
Unlike raw-loader, it remains off by default to be backwards-compatible with the other 1.x.x versions.