### PR TITLE
Upgrading Jasmine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2889,39 +2889,20 @@
       }
     },
     "jasmine": {
-      "version": "3.99.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.99.0.tgz",
-      "integrity": "sha512-YIThBuHzaIIcjxeuLmPD40SjxkEcc8i//sGMDKCgkRMVgIwRJf5qyExtlJpQeh7pkeoBSOe6lQEdg+/9uKg9mw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-4.0.2.tgz",
+      "integrity": "sha512-YsrgxJQEggxzByYe4j68eQLOiQeSrPDYGv4sHhGBp3c6HHdq+uPXeAQ73kOAQpdLZ3/0zN7x/TZTloqeE1/qIA==",
       "dev": true,
       "requires": {
         "glob": "^7.1.6",
-        "jasmine-core": "~3.99.0"
+        "jasmine-core": "^4.0.0"
       }
     },
     "jasmine-core": {
-      "version": "3.99.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.99.0.tgz",
-      "integrity": "sha512-+ZDaJlEfRopINQqgE+hvzRyDIQDeKfqqTvF8RzXsvU1yE3pBDRud2+Qfh9WvGgRpuzqxyQJVI6Amy5XQ11r/3w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.0.0.tgz",
+      "integrity": "sha512-tq24OCqHElgU9KDpb/8O21r1IfotgjIzalfW9eCmRR40LZpvwXT68iariIyayMwi0m98RDt16aljdbwK0sBMmQ==",
       "dev": true
-    },
-    "jasmine-reporters": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/jasmine-reporters/-/jasmine-reporters-2.3.2.tgz",
-      "integrity": "sha512-u/7AT9SkuZsUfFBLLzbErohTGNsEUCKaQbsVYnLFW1gEuL2DzmBL4n8v90uZsqIqlWvWUgian8J6yOt5Fyk/+A==",
-      "dev": true,
-      "requires": {
-        "mkdirp": "^0.5.1",
-        "xmldom": "^0.1.22"
-      }
-    },
-    "jasmine-xml-reporter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/jasmine-xml-reporter/-/jasmine-xml-reporter-1.2.1.tgz",
-      "integrity": "sha1-fKoqUYAv7+2+JLPqinrUJ8nqfbM=",
-      "dev": true,
-      "requires": {
-        "jasmine-reporters": "^2.2.0"
-      }
     },
     "jest-worker": {
       "version": "27.5.1",
@@ -3168,15 +3149,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
-    },
-    "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
     },
     "ms": {
       "version": "2.1.2",
@@ -4356,12 +4328,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "xmldom": {
-      "version": "0.1.31",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
-      "dev": true
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "eslint-plugin-github": "^4.3.5",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jsdoc": "^37.9.2",
-    "jasmine": "^3.99.0",
-    "jasmine-xml-reporter": "^1.2.1",
+    "jasmine": "^4.0.2",
     "nyc": "^15.1.0",
     "source-map-support": "^0.5.21",
     "ts-node": "^10.5.0",
@@ -40,7 +39,7 @@
     "build": "npx tsc",
     "clean": "rm -rf ./build",
     "lint": "npx eslint \"**/*.ts\" \"**/*.js\"",
-    "test": "npx nyc -r cobertura -r text ./node_modules/jasmine-xml-reporter/bin/jasmine.js ./build/__tests__/*.test.js --junitreport --output=build/"
+    "test": "npx nyc -r cobertura -r text ./node_modules/jasmine/bin/jasmine.js ./build/__tests__/*.test.js --output=build/"
   },
   "files": [
     "bin/*",


### PR DESCRIPTION
Removed the JUnit output, as jasmine-xml-reporter no longer seems
to be maintained, and has some security vulnerabilities in
dependencies reported by GitHub.