### PR TITLE
Fix line ending normalization

### DIFF
--- a/src/minify.ts
+++ b/src/minify.ts
@@ -458,7 +458,7 @@ export class GlslMinify {
     let output = content;
 
     // Remove carriage returns. Use newlines only.
-    output = output.replace('\r', '');
+    output = output.replace(/\r/g, '');
 
     // Strip any #version directives
     if (this.options.stripVersion) {


### PR DESCRIPTION
I think in the method `preprocessPass1` in `minify.ts` there is a bug:

`output = output.replace('\r', '');` 

This code will only replace the first occurrence of `\r` so it won't do proper line ending normalization. This PR fixes that.