### PR TITLE
Export GlslMinify

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,4 +7,4 @@
 import { webpackLoader } from './webpack';
 export default webpackLoader;
 
-export { GlslVariable, GlslVariableMap, GlslShader } from './minify';
+export { GlslVariable, GlslVariableMap, GlslShader, GlslMinify } from './minify';


### PR DESCRIPTION
As far as I understand this package it is currently not possible to use it without webpack or the cli. This PR should fix that by exporting `GlslMinify` in `index.ts` which is the main entry defined in `package.json`.