### PR TITLE
Add `texture` to builtin functions

### DIFF
--- a/src/minify.ts
+++ b/src/minify.ts
@@ -127,7 +127,7 @@ const glslBuiltinFunctions = [
   'mix', 'step', 'smoothstep',
 
   // Texture functions
-  'texture2D', 'texture2DProj', 'textureCube', 'textureSize',
+  'texture2D', 'texture2DProj', 'textureCube', 'textureSize', 'texture',
 
   // Noise functions
   'noise1', 'noise2', 'noise3', 'noise4',


### PR DESCRIPTION
The function `texture` is a builtin function that replaces `texture2D` etc. -- it shouldn't be mangled :)
Fixes #64